### PR TITLE
Add R package 'RANN'

### DIFF
--- a/manifests/r.pp
+++ b/manifests/r.pp
@@ -59,6 +59,9 @@ class datashield::r ($opal_password = 'password', $server_side = true,
   ::r::package { 'testthat':
     dependencies => true,
   }
+  ::r::package { 'RANN':
+    dependencies => true,
+  }
 
   if ($server_side){
     datashield::server_package { 'dsBase':


### PR DESCRIPTION
R Package 'RANN' is now required by "dsBetaTest"'s scatterPlotDS.o function.